### PR TITLE
Update Microsoft.AstNetCore to latest version, v2.0.0 has security vulnerabilities

### DIFF
--- a/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
+++ b/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.0" />


### PR DESCRIPTION
## Background
Existing `Microsoft.ASPNetCore` version has several security vulnerabilities which impacts using it in other OSS tools. Updating the Nuget package to latest released version i.e. **v2.2.0**.

> Listed vulnerabilities include: -
> * [<span style="color:orange">Medium</span>] https://nvd.nist.gov/vuln/detail/CVE-2017-11770
> * [<span style="color:orange">Medium</span>] https://nvd.nist.gov/vuln/detail/CVE-2018-0784 
> * [<span style="color:orange">Medium</span>] https://nvd.nist.gov/vuln/detail/CVE-2018-0785
> * [<span style="color:red">High</span>] https://nvd.nist.gov/vuln/detail/CVE-2018-0808
